### PR TITLE
Make source deploy folder configurable

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -69,7 +69,7 @@
           var execLocal = require('child_process').exec;
           var child;
 
-          child = execLocal("scp -r . " + server.username + "@" + server.host + ":" + options.deploy_path + "/releases/" + timeStamp, function (error, stdout, stderr) {
+          child = execLocal("scp -r " + (options.source_path || ".") + " " + server.username + "@" + server.host + ":" + options.deploy_path + "/releases/" + timeStamp, function (error, stdout, stderr) {
             console.log('end deploy');
 
             console.log('executing cmds after deploy');


### PR DESCRIPTION
Hi,

I recently used the grunt-deploy plugin and it works great. One thing I found is that I want to deploy only part of my project. Typically in a Grunt/bower project there is a build phase, e.g. 'dist' which has all the files needed for deploy.

With my code change, and an added lite to the Gruntfile.js, the deploys are a bit faster;
source_path: 'dist/.',

I did not add any tests, but the change is small and it seems to work as intended. So I'd be happy if you pulled it.

Thanks for a great plugin,
Martin
