### PR TITLE
Local path option, command tokens, and delayed symlink change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "*",
+    "grunt-contrib-clean": "*",
+    "grunt-contrib-nodeunit": "*",
+    "grunt": "*",
     "ssh2": "*",
     "moment": "*"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "moment": "*"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "*"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -30,7 +30,10 @@
 
       var exec = function(cmd, showLog, next){
 
-        //console.log(server.username + "@" + server.host + ":~$ " + cmd);
+        cmd = cmd.replace('$LOCAL_PATH', options.local_path);
+        cmd = cmd.replace('$DEPLOY_PATH', options.deploy_path);
+        cmd = cmd.replace('$RELEASE_PATH', options.releasePath);
+
         connection.exec(cmd, function(err, stream) {
           if (err) {throw err;}
           stream.on('data', function(data, extended) {
@@ -48,7 +51,7 @@
         }
         else{
           exec(cmds[index++], showLog, function(){
-            execCmds(cmds,index,next);
+            execCmds(cmds,index,showLog,next);
           })
         }
       }
@@ -57,13 +60,13 @@
       execCmds(options.cmds_before_deploy, 0, true, function(){
         console.log('cmds before deploy executed');
 
-
         var createFolder = 'cd ' + options.deploy_path + '/releases && mkdir ' + timeStamp;
+        options.releasePath = options.deploy_path + '/releases/' + timeStamp;
         var removeCurrent = 'rm -rf ' + options.deploy_path + '/current';
         var setCurrent = 'ln -s ' + options.deploy_path + '/releases/' + timeStamp + ' ' + options.deploy_path + '/current';
         
         console.log('start deploy');
-        exec(createFolder + ' && ' + removeCurrent + ' && ' + setCurrent, false,function(){
+        exec(createFolder, true, function(){
 
           var sys = require('sys')
           var execLocal = require('child_process').exec;
@@ -72,11 +75,12 @@
 
           child = execLocal("scp -r " + localPath + " " + server.username + "@" + server.host + ":" + options.deploy_path + "/releases/" + timeStamp, function (error, stdout, stderr) {
             console.log('end deploy');
-
-            console.log('executing cmds after deploy');
-            execCmds(options.cmds_after_deploy, 0, true, function(){
-              console.log('cmds after deploy executed');
-              connection.end();
+            exec(removeCurrent + ' && ' + setCurrent, true, function () {
+              console.log('executing cmds after deploy');
+              execCmds(options.cmds_after_deploy, 0, true, function(){
+                console.log('cmds after deploy executed');
+                connection.end();
+              });
             });
           });
         })

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -68,8 +68,9 @@
           var sys = require('sys')
           var execLocal = require('child_process').exec;
           var child;
+          var localPath = options.local_path || '.';
 
-          child = execLocal("scp -r . " + server.username + "@" + server.host + ":" + options.deploy_path + "/releases/" + timeStamp, function (error, stdout, stderr) {
+          child = execLocal("scp -r " + localPath + " " + server.username + "@" + server.host + ":" + options.deploy_path + "/releases/" + timeStamp, function (error, stdout, stderr) {
             console.log('end deploy');
 
             console.log('executing cmds after deploy');


### PR DESCRIPTION
- Added a config option to specify where the deploy should be sourced from, but it still defaults to the current path.
- Added command tokens that will be replaced by the appropriate value: $LOCAL_PATH resolves to options.local_path, $DEPLOY_PATH resolves to options.release_path, and $RELEASE_PATH resolves to the complete release path that is generated by the script (eg, /path/to/deploy/path/releases/20131116000000/)
- Delayed the moving of the symlink until after the deploy is finished to prevent any outages. It may make sense to deploy this even further until after the post commands have been run.
